### PR TITLE
Cross-Site Scripting (XSS) in frappe-charts

### DIFF
--- a/bounties/npm/frappe-charts/1/README.md
+++ b/bounties/npm/frappe-charts/1/README.md
@@ -2,7 +2,7 @@
 
 `frappe-charts` is vulnerable to `Cross-Site Scripting (XSS)`.
 
-# Steps To Reproduce-:  
+# Steps To Reproduce
 
 1. Open NPM repo https://www.npmjs.com/package/frappe-charts
 2. Open the Explore demos https://frappe.io/charts

--- a/bounties/npm/frappe-charts/1/README.md
+++ b/bounties/npm/frappe-charts/1/README.md
@@ -1,0 +1,12 @@
+# Description
+
+`frappe-charts` is vulnerable to `Cross-Site Scripting (XSS)`.
+
+# Steps To Reproduce-:  
+
+1. Open NPM repo https://www.npmjs.com/package/frappe-charts
+2. Open the Explore demos https://frappe.io/charts
+3. At the bottom find the sandbox Ref: https://codesandbox.io/s/frappe-charts-demo-viqud?from-embed=&file=/src/index.js
+4. Use the payload `"><img/&#09;&#10;&#11; src=`~` onerror=alert('XSS')>` and place it in 
+          name: "Some Data'><img/&#09;&#10;&#11; src=`~` onerror=alert(document.domain)>",
+5. XSS payload will get executed.

--- a/bounties/npm/frappe-charts/1/vulnerability.json
+++ b/bounties/npm/frappe-charts/1/vulnerability.json
@@ -1,0 +1,55 @@
+{
+    "PackageVulnerabilityID": "1",
+    "DisclosureDate": "2020-11-03",
+    "AffectedVersionRange": "*",
+    "Summary": "Cross-site Scripting",
+    "Contributor": {
+        "Discloser": "",
+        "Fixer": ""
+    },
+    "Package": {
+        "Registry": "npm",
+        "Name": "frappe-charts",
+        "URL": "https://www.npmjs.com/package/frappe-charts",
+        "Downloads": "7,204"
+    },
+    "CWEs": [
+        {
+            "ID": "79",
+            "Description": "Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')"
+        }
+    ],
+    "CVSS":
+    {
+        "Version": "3.1",
+        "AV": "N",
+        "AC": "L",
+        "PR": "N",
+        "UI": "R",
+        "S": "U",
+        "C": "L",
+        "I": "L",
+        "A": "N",
+        "E": "",
+        "RL": "",
+        "RC": "",
+        "Score": "6.1"
+    },
+    "CVEs": [
+        ""
+    ],
+    "Repository": {
+        "URL": "https://github.com/frappe/charts",
+        "Codebase": [
+            "JavaScript"
+        ],
+        "Owner": "frappe",
+        "Name": "frappe",
+        "Forks": 596,
+        "Stars": 13600
+    },
+    "Permalinks": [
+        "https://github.com/frappe/charts/issues/313"
+    ],
+    "References": []
+}

--- a/bounties/npm/frappe-charts/1/vulnerability.json
+++ b/bounties/npm/frappe-charts/1/vulnerability.json
@@ -2,7 +2,7 @@
     "PackageVulnerabilityID": "1",
     "DisclosureDate": "2020-11-03",
     "AffectedVersionRange": "*",
-    "Summary": "Cross-site Scripting",
+    "Summary": "Cross-site Scripting (XSS)",
     "Contributor": {
         "Discloser": "",
         "Fixer": ""
@@ -44,12 +44,17 @@
             "JavaScript"
         ],
         "Owner": "frappe",
-        "Name": "frappe",
+        "Name": "charts",
         "Forks": 596,
         "Stars": 13600
     },
     "Permalinks": [
         "https://github.com/frappe/charts/issues/313"
     ],
-    "References": []
+    "References": [
+        {
+            "Description": "GitHub Issue",
+            "URL": "https://github.com/frappe/charts/issues/313"
+        }
+    ]
 }


### PR DESCRIPTION
`frappe-charts` is vulnerable to `Cross-Site Scripting (XSS)`.

# Steps To Reproduce-:  

1. Open NPM repo https://www.npmjs.com/package/frappe-charts
2. Open the Explore demos https://frappe.io/charts
3. At the bottom find the sandbox Ref: https://codesandbox.io/s/frappe-charts-demo-viqud?from-embed=&file=/src/index.js
4. Use the payload `'><img/&#09;&#10;&#11; src=`~` onerror=alert('XSS')>` and place it in 
          name: "Some Data-PAYLOAD",
5. XSS payload will get executed.